### PR TITLE
Filter "holds" when switching between Friend City to Friend Country map and back

### DIFF
--- a/src/components/Prompts/FilterCityMap.js
+++ b/src/components/Prompts/FilterCityMap.js
@@ -7,13 +7,12 @@ import DoNotRecommendIcon from "../../icons/DoNotRecommendIcon";
 
 function FilterCityMap(props) {
   const [usernameArray, handleUsernameChange] = useState(
-    props.customProps.filterSettings.username !== undefined
+    (props.customProps.filterSettings !== null)
       ? props.customProps.filterSettings.username
       : []
   );
   const [interestTagArray, handleInterestTag] = useState([]);
   const [friendDetails, handleFriendDetails] = useState([]);
-
   function handleUsernameChangeHelper(e) {
     if (e.key === "Enter" || e.key === "Unidentified") {
       let newUsernameArray = [...usernameArray];

--- a/src/pages/Home/FriendMapPage.js
+++ b/src/pages/Home/FriendMapPage.js
@@ -4,13 +4,31 @@ import { GET_ALL_USER_COUNTRIES } from "../../GraphQL";
 import FriendCountryMap from "./subcomponents/FriendCountryMap";
 import FriendCityMap from "./subcomponents/FriendCityMap";
 import Loader from "../../components/common/Loader/Loader";
-import LeaderboardCard from "./subcomponents/LeaderboardCard";
 
 const FriendMapPage = () => {
   const [loaded, handleLoaded] = useState(false);
   const [cityOrCountry, handleMapTypeChange] = useState(1);
   const [clickedCountryArray, addCountry] = useState([]);
   const [tripData, handleTripData] = useState([]);
+  const [clickedCityArray, handleClickedCityArray] = useState([]);
+  const [filteredCityArray, handleFilteredCityArray] = useState([]);
+  const [filterParams, handleFilterParams] = useState(null);
+
+  function handleCities(cities) {
+    handleClickedCityArray(cities);
+    
+  }
+
+  function handleFilteredCities(cities) {
+    handleFilteredCityArray(cities);
+  }
+
+  function handleFilter(filterParams) {
+    handleFilterParams(filterParams);
+    if (filterParams === null) {
+      handleFilteredCityArray(clickedCityArray);
+    }
+  }
 
   function handleLoadedCountries(data) {
     let countryArray = clickedCountryArray;
@@ -95,7 +113,12 @@ const FriendMapPage = () => {
                 <FriendCityMap
                   tripData={tripData}
                   handleMapTypeChange={handleMapTypeChange}
+                  handleFilter={handleFilter}
                   data={data}
+                  filterParams={filterParams}
+                  handleCities={handleCities}
+                  tripCities={filteredCityArray}
+                  handleFilteredCities={handleFilteredCities}
                 />
               ) : (
                 <FriendCountryMap
@@ -103,6 +126,7 @@ const FriendMapPage = () => {
                   tripData={tripData}
                   handleMapTypeChange={handleMapTypeChange}
                   refetch={refetch}
+                  filterParams={filterParams}
                 />
               )}
             </div>

--- a/src/pages/Home/subcomponents/FriendCityMap.js
+++ b/src/pages/Home/subcomponents/FriendCityMap.js
@@ -55,54 +55,40 @@ function FriendCityMap(props) {
       handleLoadedCities(props.tripData);
     } else {
       handleLoadedMarkers(clickedCityArray);
-      let pastCount = 0;
-      let futureCount = 0;
-      let liveCount = 0;
-      for (let i in clickedCityArray) {
-        switch (clickedCityArray[i].tripTiming) {
-          case 0:
-            pastCount++;
-            break;
-          case 1:
-            futureCount++;
-            break;
-          case 2:
-            liveCount++;
-            break;
-          default:
-            break;
-        }
-      }
-      handleTripTimingCounts([pastCount, futureCount, liveCount]);
+      calculateTripTimingCounts(clickedCityArray);
     }
     return function cleanup() {
       window.removeEventListener("resize", resize);
     };
   }, []);
 
+  function calculateTripTimingCounts(cityArray) {
+    let pastCount = 0;
+    let futureCount = 0;
+    let liveCount = 0;
+    for (let i in cityArray) {
+      switch (cityArray[i].tripTiming) {
+        case 0:
+          pastCount++;
+          break;
+        case 1:
+          futureCount++;
+          break;
+        case 2:
+          liveCount++;
+          break;
+        default:
+          break;
+      }
+    }
+    handleTripTimingCounts([pastCount, futureCount, liveCount]);
+  }
+
   useEffect(() => {
     handleClickedCityArray(props.tripCities);
     if (props.tripCities.length >= 1 && props.tripCities !== undefined) {
       handleLoadedMarkers(props.tripCities);
-      let pastCount = 0;
-      let futureCount = 0;
-      let liveCount = 0;
-      for (let i in props.tripCities) {
-        switch (props.tripCities[i].tripTiming) {
-          case 0:
-            pastCount++;
-            break;
-          case 1:
-            futureCount++;
-            break;
-          case 2:
-            liveCount++;
-            break;
-          default:
-            break;
-        }
-      }
-      handleTripTimingCounts([pastCount, futureCount, liveCount]);
+      calculateTripTimingCounts(props.tripCities);
     }
   }, [props.tripCities]);
 
@@ -768,7 +754,7 @@ FriendCityMap.propTypes = {
   data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   handleFilter: PropTypes.func,
   filterParams: PropTypes.object,
-  tripCities: PropTypes.array, 
+  tripCities: PropTypes.array,
   handleCities: PropTypes.func,
   handleFilteredCities: PropTypes.func
 };

--- a/src/pages/Home/subcomponents/FriendCityMap.js
+++ b/src/pages/Home/subcomponents/FriendCityMap.js
@@ -32,7 +32,7 @@ function FriendCityMap(props) {
   const [filteredTripTimingCounts, handleFilteredTripTimingCounts] = useState(
     null
   );
-  const [clickedCityArray, handleClickedCityArray] = useState([]);
+  const [clickedCityArray, handleClickedCityArray] = useState(props.tripCities);
   const [filteredCityArray, handleFilteredCityArray] = useState([]);
   const [activeTimings, handleActiveTimings] = useState([1, 1, 1]);
   const [loading, handleLoaded] = useState(true);
@@ -41,22 +41,70 @@ function FriendCityMap(props) {
   const [hoveredCityArray, handleHoveredCityArray] = useState(null);
   const [filter, handleFilter] = useState(false);
   const [leaderboard, handleLeaderboard] = useState(false);
-  const [filterSettings, handleFilterSettings] = useState([]);
+  const [filterSettings, handleFilterSettings] = useState(props.filterParams);
   const [clickedCity, handleClickedCity] = useState(null);
   const [showSideMenu, handleSideMenu] = useState(false);
   const mapRef = useRef();
   const clusterPast = useRef();
   const clusterFuture = useRef();
   const clusterLive = useRef();
-
   useEffect(() => {
     window.addEventListener("resize", resize);
     resize();
-    handleLoadedCities(props.tripData);
+    if (clickedCityArray.length < 1 || clickedCityArray === undefined) {
+      handleLoadedCities(props.tripData);
+    } else {
+      handleLoadedMarkers(clickedCityArray);
+      let pastCount = 0;
+      let futureCount = 0;
+      let liveCount = 0;
+      for (let i in clickedCityArray) {
+        switch (clickedCityArray[i].tripTiming) {
+          case 0:
+            pastCount++;
+            break;
+          case 1:
+            futureCount++;
+            break;
+          case 2:
+            liveCount++;
+            break;
+          default:
+            break;
+        }
+      }
+      handleTripTimingCounts([pastCount, futureCount, liveCount]);
+    }
     return function cleanup() {
       window.removeEventListener("resize", resize);
     };
   }, []);
+
+  useEffect(() => {
+    handleClickedCityArray(props.tripCities);
+    if (props.tripCities.length >= 1 && props.tripCities !== undefined) {
+      handleLoadedMarkers(props.tripCities);
+      let pastCount = 0;
+      let futureCount = 0;
+      let liveCount = 0;
+      for (let i in props.tripCities) {
+        switch (props.tripCities[i].tripTiming) {
+          case 0:
+            pastCount++;
+            break;
+          case 1:
+            futureCount++;
+            break;
+          case 2:
+            liveCount++;
+            break;
+          default:
+            break;
+        }
+      }
+      handleTripTimingCounts([pastCount, futureCount, liveCount]);
+    }
+  }, [props.tripCities]);
 
   function resize() {
     handleViewportChange({
@@ -316,11 +364,6 @@ function FriendCityMap(props) {
         }
       }
       if (data != null && data[i].Place_living !== null) {
-        // if (
-        //   !clickedCityArray.some(city => {
-        //     return city.cityId === data[i].Place_living.cityId;
-        //   })
-        // ) {
         clickedCityArray.push({
           id: data[i].Place_living.id,
           username: data[i].username,
@@ -342,6 +385,7 @@ function FriendCityMap(props) {
     }
     let filteredCityArray = clickedCityArray;
     handleClickedCityArray(clickedCityArray);
+    props.handleCities(clickedCityArray);
     handleFilteredCityArray(filteredCityArray);
     handleTripTimingCounts([pastCount, futureCount, liveCount]);
     handleLoadedMarkers(filteredCityArray);
@@ -398,14 +442,16 @@ function FriendCityMap(props) {
   }
 
   function handleFilterCleared() {
+    props.handleFilter(null);
     let filteredCityArray = [...clickedCityArray];
     handleFilteredCityArray(filteredCityArray);
     handleFilteredTripTimingCounts(null);
     handleLoadedMarkers(filteredCityArray);
-    handleFilterSettings([]);
+    handleFilterSettings(null);
   }
 
   function handleFilterHelper(filterParams) {
+    props.handleFilter(filterParams);
     let origCityArray = [...clickedCityArray];
     let filteredCityArray;
     if (filterParams.username.length > 0) {
@@ -413,6 +459,7 @@ function FriendCityMap(props) {
         city => filterParams.username.indexOf(city.username) !== -1
       );
       handleFilteredCityArray(filteredCityArray);
+      props.handleFilteredCities(filteredCityArray);
       handleLoadedMarkers(filteredCityArray);
     } else if (filterParams.username.length < 1) {
       handleFilterCleared();
@@ -493,7 +540,7 @@ function FriendCityMap(props) {
             </span>
           </div>
           <div
-            id={filteredTripTimingCounts !== null ? "fc-filter-active" : null}
+            id={props.filterParams !== null ? "fc-filter-active" : null}
             className="sc-controls sc-controls-right"
             onClick={showFilter}
           >
@@ -561,7 +608,7 @@ function FriendCityMap(props) {
                   </div>
                   <div
                     id={
-                      filteredTripTimingCounts !== null
+                      props.filterParams !== null
                         ? "fc-filter-active"
                         : "fc-filter"
                     }
@@ -576,7 +623,9 @@ function FriendCityMap(props) {
                     </span>
                   </div>
                   <div
-                    id={leaderboard ? "fc-leaderboard-active" : "fc-leaderboard"}
+                    id={
+                      leaderboard ? "fc-leaderboard-active" : "fc-leaderboard"
+                    }
                     className="sc-controls sc-controls-left-two"
                     onClick={() => handleLeaderboard(!leaderboard)}
                   >
@@ -716,7 +765,12 @@ function FriendCityMap(props) {
 FriendCityMap.propTypes = {
   tripData: PropTypes.array,
   handleMapTypeChange: PropTypes.func,
-  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object])
+  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  handleFilter: PropTypes.func,
+  filterParams: PropTypes.object,
+  tripCities: PropTypes.array, 
+  handleCities: PropTypes.func,
+  handleFilteredCities: PropTypes.func
 };
 
 ClusterMarker.propTypes = {

--- a/src/pages/Home/subcomponents/FriendCountryMap.js
+++ b/src/pages/Home/subcomponents/FriendCountryMap.js
@@ -38,6 +38,12 @@ const FriendCountryMap = props => {
   const [tripTimingCounts, handleTripTiming] = useState([0, 0, 0]);
   const [activeTimings, handleTimingCheckbox] = useState([1, 1, 1]);
   const [showSideMenu, handleSideMenu] = useState(false);
+  const [filteredCountryArray, handleFilteredCountries] = useState(null);
+  const [filteredTripTimingCounts, handleFilteredTripTimingCounts] = useState([
+    0,
+    0,
+    0
+  ]);
 
   useEffect(() => {
     handleLoadedCountries(props.tripData);
@@ -119,11 +125,6 @@ const FriendCountryMap = props => {
         ) {
           liveCount++;
         }
-        // if (
-        //   !countryArray.some(city => {
-        //     return city.cityId === data[i].Place_living.cityId;
-        //   })
-        // ) {
         countryArray.push({
           id: data[i].Place_living.id,
           username: data[i].username,
@@ -137,11 +138,46 @@ const FriendCountryMap = props => {
           avatarIndex: data[i].avatarIndex !== null ? data[i].avatarIndex : 1,
           color: data[i].color
         });
-        // }
       }
     }
     handleCountryArray(countryArray);
+    handleFilteredCountries(countryArray);
     handleTripTiming([pastCount, futureCount, liveCount]);
+    handleFilteredTripTimingCounts([pastCount, futureCount, liveCount]);
+    if (props.filterParams !== null) {
+      handleFilter();
+    }
+  }
+
+  function handleFilter() {
+    let filterParams = props.filterParams;
+    let filteredCountryArray = countryArray.filter(
+      country => filterParams.username.indexOf(country.username) !== -1
+    );
+    let uniqueFilteredCountryArray = filteredCountryArray.filter(
+      (value, index, self) =>
+        self.map(country => country.countryId).indexOf(value.countryId) == index
+    );
+    let pastCount = 0;
+    let futureCount = 0;
+    let liveCount = 0;
+    for (let i in uniqueFilteredCountryArray) {
+      switch (uniqueFilteredCountryArray[i].tripTiming) {
+        case 0:
+          pastCount++;
+          break;
+        case 1:
+          futureCount++;
+          break;
+        case 2:
+          liveCount++;
+          break;
+        default:
+          break;
+      }
+    }
+    handleFilteredCountries(filteredCountryArray);
+    handleFilteredTripTimingCounts([pastCount, futureCount, liveCount]);
   }
 
   function handleContinentClick(evt) {
@@ -160,11 +196,13 @@ const FriendCountryMap = props => {
     let isCountryIncluded = false;
     let countryTiming = null;
     let countryTimingArray = [];
-    for (let i in countryArray) {
-      if (countryArray[i].countryId === geography.id) {
+    for (let i in filteredCountryArray) {
+      if (filteredCountryArray[i].countryId === geography.id) {
         isCountryIncluded = true;
-        countryTiming = countryArray[i].tripTiming;
-        if (countryTimingArray.indexOf(countryArray[i].tripTiming) === -1) {
+        countryTiming = filteredCountryArray[i].tripTiming;
+        if (
+          countryTimingArray.indexOf(filteredCountryArray[i].tripTiming) === -1
+        ) {
           countryTimingArray.push(countryTiming);
         }
       }
@@ -227,7 +265,7 @@ const FriendCountryMap = props => {
             <div className="side-menu-container">
               <div className="city-new-map-scorecard" id="scorecard-side-menu">
                 <MapScorecard
-                  tripTimingCounts={tripTimingCounts}
+                  tripTimingCounts={filteredTripTimingCounts}
                   activeTimings={activeTimings}
                   sendActiveTimings={handleActiveTimings}
                 />
@@ -331,7 +369,7 @@ const FriendCountryMap = props => {
       ) : null}
       <div id="new-country-scorecard">
         <MapScorecard
-          tripTimingCounts={tripTimingCounts}
+          tripTimingCounts={filteredTripTimingCounts}
           activeTimings={activeTimings}
           sendActiveTimings={handleActiveTimings}
         />
@@ -346,7 +384,8 @@ FriendCountryMap.propTypes = {
   clickedCountryArray: PropTypes.array,
   tripData: PropTypes.array,
   handleMapTypeChange: PropTypes.func,
-  refetch: PropTypes.func
+  refetch: PropTypes.func, 
+  filterParams: PropTypes.object
 };
 
 export default FriendCountryMap;


### PR DESCRIPTION
…ching map types'

<!--- Provide a general summary of your changes in the Title above -->

## Description

Filter is still set in the "Friend City Map" but the filter (currently just usernames) will stay in place when switching between city -> country -> city map. The filter must be cleared to return to an unfiltered map. There was also some logic added to have the parent "FriendMapPage" component hold on to the filterParams and cityArray to minimize the amount of "building" an array each time the country or city map is switched to. The logic here is rather messy, could probably use a re-vamp and perhaps more logic in the parent rather than the two children components to avoid re-calculation or building of arrays. 


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
