### PR TITLE
Centering login form using flexbox's justify contents instead of absolute positioning.

### DIFF
--- a/src/pages/Landing/subcomponents/LandingForm.js
+++ b/src/pages/Landing/subcomponents/LandingForm.js
@@ -12,27 +12,27 @@ function LandingForm({ setFormIsOpen }) {
       <div className="landing-form">
         <div className="landing-choice-container">
           <div className="header-text-container">
-          <span
-            className={
-              formActive === false
-                ? "landing-choice landing-choice-active"
-                : "landing-choice"
-            }
-            onClick={() => handleFormSwitch(false)}
-          >
-            Login
-          </span>
-          <span style={{ color: "#747474" }}>or </span>
-          <span
-            className={
-              formActive === true
-                ? "landing-choice landing-choice-active"
-                : "landing-choice"
-            }
-            onClick={() => handleFormSwitch(true)}
-          >
-            Sign Up
-          </span>
+            <span
+              className={
+                formActive === false
+                  ? "landing-choice landing-choice-active"
+                  : "landing-choice"
+              }
+              onClick={() => handleFormSwitch(false)}
+            >
+              Login
+            </span>
+            <span style={{ color: "#747474" }}>or </span>
+            <span
+              className={
+                formActive === true
+                  ? "landing-choice landing-choice-active"
+                  : "landing-choice"
+              }
+              onClick={() => handleFormSwitch(true)}
+            >
+              Sign Up
+            </span>
           </div>
           <div
             onClick={() => setFormIsOpen(false)}

--- a/src/pages/Landing/subcomponents/LandingForm.js
+++ b/src/pages/Landing/subcomponents/LandingForm.js
@@ -8,48 +8,52 @@ import CloseWindowIcon from "../../../icons/CloseWindowIcon";
 function LandingForm({ setFormIsOpen }) {
   const [formActive, handleFormSwitch] = useState(localStorage.clickedCityArray !== undefined || localStorage.friendClickedCityArray !== undefined ? true : false);
   return (
-    <div className="landing-form">
-      <div
-        onClick={() => setFormIsOpen(false)}
-        className="close-icon-container"
-      >
-        <CloseWindowIcon />
-      </div>
-      <div className="landing-choice-container">
-        <span
-          className={
-            formActive === false
-              ? "landing-choice landing-choice-active"
-              : "landing-choice"
-          }
-          onClick={() => handleFormSwitch(false)}
-        >
-          Login
-        </span>
-        <span style={{ color: "#747474" }}>or </span>
-        <span
-          className={
-            formActive === true
-              ? "landing-choice landing-choice-active"
-              : "landing-choice"
-          }
-          onClick={() => handleFormSwitch(true)}
-        >
-          Sign Up
-        </span>
-      </div>
-      <div className="landing-form-content">
-        {formActive ? (
-          <SignupForm
-            setFormIsOpen={setFormIsOpen}
-            handleFormSwitch={() => handleFormSwitch(false)}
-          />
-        ) : (
-          <LoginForm
-            setFormIsOpen={setFormIsOpen}
-            handleFormSwitch={() => handleFormSwitch(true)}
-          />
-        )}
+    <div className="landing-form-container">
+      <div className="landing-form">
+        <div className="landing-choice-container">
+          <div className="header-text-container">
+          <span
+            className={
+              formActive === false
+                ? "landing-choice landing-choice-active"
+                : "landing-choice"
+            }
+            onClick={() => handleFormSwitch(false)}
+          >
+            Login
+          </span>
+          <span style={{ color: "#747474" }}>or </span>
+          <span
+            className={
+              formActive === true
+                ? "landing-choice landing-choice-active"
+                : "landing-choice"
+            }
+            onClick={() => handleFormSwitch(true)}
+          >
+            Sign Up
+          </span>
+          </div>
+          <div
+            onClick={() => setFormIsOpen(false)}
+            className="close-icon-container"
+          >
+            <CloseWindowIcon />
+          </div>
+        </div>
+        <div className="landing-form-content">
+          {formActive ? (
+            <SignupForm
+              setFormIsOpen={setFormIsOpen}
+              handleFormSwitch={() => handleFormSwitch(false)}
+            />
+          ) : (
+            <LoginForm
+              setFormIsOpen={setFormIsOpen}
+              handleFormSwitch={() => handleFormSwitch(true)}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Landing/subcomponents/_LandingForm.scss
+++ b/src/pages/Landing/subcomponents/_LandingForm.scss
@@ -1,45 +1,41 @@
 .landing-form {
-  position: absolute;
-  top: 60px;
   opacity: 1;
   background: rgba(37, 41, 49, 1) !important;
-  z-index: 10;
-  @media (max-width: 1100px) {
-    left: 50%;
-  }  
-  @media (max-width: 1000px) {
-    top: 106px;
-    left: calc(50% - 162px);
-   }
-  .close-icon-container {
-    cursor: pointer;
-    .close-window-icon {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: rgb(168, 168, 172);
-      position: absolute;
-      right: 10px;
-      top: 10px;
-      width: 20px;
-      height: 20px;
-      border-radius: 50%;
-      border: 1px solid rgb(168, 168, 172);
-      span {
-        line-height: 8px;
-        height: 12px;
-        width: 12px;
-        text-align: center;
-      }
-      &:hover {
-        color: rgb(248, 248, 252);
-        border: 1px solid rgb(248, 248, 252);
-      }
+  max-width: fit-content;
+}
+
+.landing-form-container {
+  display: flex;
+  justify-content: center;
+  position: absolute;
+  top: 106px;
+  width: 100%;
+}
+
+.close-icon-container {
+  cursor: pointer;
+  .close-window-icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: rgb(168, 168, 172);
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: 1px solid rgb(168, 168, 172);
+    span {
+      line-height: 8px;
+      height: 12px;
+      width: 12px;
+      text-align: center;
+    }
+    &:hover {
+      color: rgb(248, 248, 252);
+      border: 1px solid rgb(248, 248, 252);
     }
   }
+}
 
-  .landing-form-container {
-    display: flex;
-    min-height: 540px;
-  }
+.header-text-container {
+  flex-grow: 1;
 }

--- a/src/pages/Landing/subcomponents/_SignupForm.scss
+++ b/src/pages/Landing/subcomponents/_SignupForm.scss
@@ -7,8 +7,7 @@
   background: rgba(#252931, 0.8);
   .landing-choice-container {
     display: flex;
-    margin-top: 40px;
-    margin-left: 20px;
+    margin: 40px 36px 0 20px;
     line-height: 20px;
     .landing-choice {
       cursor: pointer;
@@ -148,11 +147,11 @@
 
   .form-switch {
     display: flex;
-    width: 100%;
     justify-content: center;
     align-items: center;
     height: 60px;
     color: rgb(120, 120, 120);
+    min-width: 255px;
     span {
       cursor: pointer;
       margin-left: 4px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR seeks to address the issue of centering signup form and login form horizontally. A partial cause is due to the Signup form is slightly wider than the Login form.

<!--- Describe your changes in detail -->

Currently, the login/signup form is centered with absolute position top and left attributes. In this PR, only the container for the form is absolutely positioned to below the navigation bar. The login/signup form within the container is centered via flex-box.

The inconsistent width was caused by the "form-switch" element. I have added min-width to this element so that both form now has the same width.

I also moved the close button to be on the same line with the header text (Login or Signup)

## Screenshots (if appropriate):
After:
![Screen Shot 2020-03-17 at 3 06 30 PM](https://user-images.githubusercontent.com/11153258/76906328-eff23b00-6860-11ea-85b7-cf298a881707.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- Note: Also please make sure the console is empty at production and there are no eslint warnings -->

- [ ] The console is clean. No errors or linting warnings
