### PR TITLE
Country map dropdown

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -89,12 +89,14 @@ function App({ userAuthenticated }) {
             fetchPolicy={"cache-and-network"}
             partialRefetch={true}
             onCompleted={() => {
+              console.log('query re-fired')
               handleLoaded(true);
             }}
           >
             {({ loading, error, data, refetch }) => {
               if (loading) return <Loader />;
               if (error) return `Error! ${error}`;
+              console.log(data);
               handleUserData(data);
               if (!loaded) return null;
               return (

--- a/src/GraphQL.js
+++ b/src/GraphQL.js
@@ -532,7 +532,7 @@ export const UPDATE_GEORNEY_SCORE = gql`
       georneyScore
     }
   }
-`; 
+`;
 
 export const NEW_GEORNEY_SCORE = gql`
   mutation updateGeorneyScore($newTravelScore: Float!) {
@@ -541,7 +541,7 @@ export const NEW_GEORNEY_SCORE = gql`
       georneyScore
     }
   }
-`; 
+`;
 
 export const ADD_PLACE_VISITED = gql`
   mutation addPlaceVisited($country: Country!, $cities: [City!]) {
@@ -578,8 +578,8 @@ export const REMOVE_PLACE_VISITING = gql`
 `;
 
 export const REMOVE_PLACES_IN_COUNTRY = gql`
-  mutation removePlacesInCountry($countryISO: String!) {
-    removePlacesInCountry(countryISO: $countryISO) {
+  mutation removePlacesInCountry($countryISO: String!, $currentTiming: Int!) {
+    removePlacesInCountry(countryISO: $countryISO, tripTiming: $currentTiming) {
       id
       city
     }

--- a/src/components/Prompts/ClickedCountry/ClickedCountryContainer.scss
+++ b/src/components/Prompts/ClickedCountry/ClickedCountryContainer.scss
@@ -70,44 +70,7 @@
       background: orange;
     }
   }
-  .clicked-country-timing-container {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    span {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 0px 18px;
-      height: 80px;
-      font-size: 24px;
-      letter-spacing: 2px;
-      font-weight: 550;
-      &:hover {
-        cursor: pointer;
-        font-weight: 700;
-      }
-    }
-    .unclickable-timing {
-      cursor: none;
-      opacity: 0.35;
-      &:hover {
-        cursor: no-drop;
-      }
-    }
-    .past-timing {
-      color: #cb7678;
-      background: #ecd7db;
-    }
-    .future-timing {
-      color: #73a7c3;
-      background: #c2d7e5;
-    }
-    .live-timing {
-      color: #96b1a8;
-      background: #d1dcdb;
-    }
-  }
+
   .city-counter-container {
     display: flex;
     justify-content: space-between;
@@ -122,7 +85,25 @@
   }
 }
 
-.previous-trips-button {
+.clicked-country-timing-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 400px;
+  max-width: 320px;
+  span {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0px 18px;
+    height: 120px;
+    font-size: 24px;
+    font-weight: 400;
+  }
+}
+
+.previous-trips-button,
+.cancel-delete-button {
   cursor: pointer;
   display: flex;
   justify-content: center;
@@ -133,8 +114,11 @@
   letter-spacing: 2px;
   font-weight: 550;
   width: 240px;
-  margin: 20px auto;
+  margin: 4px auto;
   padding-left: 0;
+}
+
+.previous-trips-button {
   color: #cb7678;
   background: rgb(228, 228, 232);
   .trash-icon-container {
@@ -153,6 +137,35 @@
   &:hover {
     background: #cb7678;
     color: rgb(228, 228, 232);
+  }
+}
+
+.cancel-delete-button {
+  color: rgb(238, 238, 242);
+  background: $primary-blue;
+
+  .back-icon-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transform: translate(-56px, 0px);
+    height: 100%;
+    min-width: 48px;
+    background: $primary-blue;
+    svg {
+      height: 30px;
+      fill: rgb(238, 238, 242);
+      transform: rotate(180deg);
+    }
+  }
+  &:hover {
+    color: white;
+    .back-icon-container {
+      background: white;
+      svg {
+        fill: $primary-blue;
+      }
+    }
   }
 }
 

--- a/src/components/Prompts/ClickedCountry/ClickedCountryTiming.js
+++ b/src/components/Prompts/ClickedCountry/ClickedCountryTiming.js
@@ -4,18 +4,24 @@ import PropTypes from "prop-types";
 import Swal from "sweetalert2";
 import DeleteCitiesPopup from "./DeleteCitiesPopup";
 import TrashIcon from "../../../icons/TrashIcon";
+import ArrowRightIcon from "../../../icons/ArrowRightIcon";
 
 function ClickedCountryTiming(props) {
-  const [countryISO] = useState(props.country);
+  const [countryISO] = useState(props.customProps.countryInfo.properties.ISO2);
   const [deletePopup, handleDeletePopup] = useState(false);
-  function handleAddCountryTiming(timing) {
-    props.handleTripTiming(timing);
-    props.handlePageChange(1);
-  }
+  const [tense] = useState(
+    props.customProps.currentTiming === "past"
+      ? "have visited"
+      : props.customProps.currentTiming === "future"
+      ? "will visit"
+      : "live in"
+  );
   function handleDeleteButton() {
     let popupText =
-      "Do you want to delete all cities associated with " +
-      props.countryName +
+      "Do you want to delete all " +
+      props.customProps.currentTiming +
+      " cities associated with " +
+      props.customProps.countryInfo.properties.name +
       "?";
     Swal.fire({
       type: "question",
@@ -33,29 +39,41 @@ function ClickedCountryTiming(props) {
   }
   function handleDeleteCities() {
     handleDeletePopup(false);
-    props.handleDelete();
+    props.customProps.refetch();
   }
   return (
     <div className="clicked-country-timing-container">
-      <span className = 'past-timing' onClick={() => handleAddCountryTiming(0)}>I visited here</span>
-      <span className = 'future-timing' onClick={() => handleAddCountryTiming(1)}>
-        I plan to visit here
+      <span>
+        You have previously indicated that you {tense}{" "}
+        {props.customProps.countryInfo.properties.name}
       </span>
-      <span className = 'live-timing' onClick={() => handleAddCountryTiming(2)}>
-        I live here currently
-      </span>
-      {props.previousTrips ? (
-        <div className="previous-trips-button" onClick={handleDeleteButton}>
-          <div className="trash-icon-container">
-            <TrashIcon />
-          </div>
-          <div>delete cities</div>
+      <span>Do you wish to delete the country and all city data?</span>
+      <div className="previous-trips-button" onClick={handleDeleteButton}>
+        <div className="trash-icon-container">
+          <TrashIcon />
         </div>
-      ) : null}
+        <div>delete cities</div>
+      </div>
+      <div
+        className="cancel-delete-button"
+        onClick={() => props.customProps.showPopup(false)}
+      >
+        <div className="back-icon-container">
+          <ArrowRightIcon />
+        </div>
+        <div>cancel</div>
+      </div>
       {deletePopup ? (
         <DeleteCitiesPopup
           countryISO={countryISO}
           handleDeleteCities={handleDeleteCities}
+          currentTiming={
+            props.customProps.currentTiming === "past"
+              ? Number(0)
+              : (props.customProps.currentTiming === "future"
+                  ? Number(1)
+                  : Number(2))
+          }
         />
       ) : null}
     </div>

--- a/src/components/Prompts/ClickedCountry/ClickedCountryTiming.js
+++ b/src/components/Prompts/ClickedCountry/ClickedCountryTiming.js
@@ -81,12 +81,7 @@ function ClickedCountryTiming(props) {
 }
 
 ClickedCountryTiming.propTypes = {
-  handleTripTiming: PropTypes.func,
-  handlePageChange: PropTypes.func,
-  handleDelete: PropTypes.func,
-  previousTrips: PropTypes.bool,
-  country: PropTypes.string,
-  countryName: PropTypes.string
+  customProps: PropTypes.array
 };
 
 export default ClickedCountryTiming;

--- a/src/components/Prompts/ClickedCountry/DeleteCitiesPopup.js
+++ b/src/components/Prompts/ClickedCountry/DeleteCitiesPopup.js
@@ -14,12 +14,14 @@ class DoMutation extends React.Component {
   }
 }
 
-function DeleteCitiesPopup({ children, countryISO, handleDeleteCities }) {
+function DeleteCitiesPopup({ children, countryISO, handleDeleteCities, currentTiming }) {
+  console.log(countryISO)
+  console.log(currentTiming)
   return (
     <div className="city-choosing-container">
       <Mutation
         mutation={REMOVE_PLACES_IN_COUNTRY}
-        variables={{ countryISO }}
+        variables={{ countryISO, currentTiming }}
         onCompleted={() => handleDeleteCities()}
       >
         {(mutation, { data, loading, error }) => (
@@ -35,6 +37,7 @@ function DeleteCitiesPopup({ children, countryISO, handleDeleteCities }) {
 
 DeleteCitiesPopup.propTypes = {
   countryISO: PropTypes.string,
+  currentTiming: PropTypes.number,
   children: PropTypes.object,
   handleDeleteCities: PropTypes.func
 };

--- a/src/pages/Home/MapPage.js
+++ b/src/pages/Home/MapPage.js
@@ -15,7 +15,7 @@ const MapPage = ({
   handleMapPageChange,
   clickedCityArray
 }) => {
-  const [clickedCountryArray, addCountry] = useState([]);
+  const [countryArray, addCountry] = useState([]);
   const [tripData, handleTripData] = useState([]);
   const [newClickedCityArray, handleClickedCityArray] = useState([]);
   const [loaded, handleLoaded] = useState(false);
@@ -29,7 +29,6 @@ const MapPage = ({
       refetch();
     }
   });
-
   useEffect(() => {
     if (
       clickedCityArray !== null &&
@@ -72,19 +71,19 @@ const MapPage = ({
     }
     handleTripData(user);
     function handleLoadedCountries(data) {
-      let countryArray = clickedCountryArray;
+      let newCountryArray = countryArray;
       let userData = data;
       if (userData != null && userData.Places_visited.length !== 0) {
         for (let i = 0; i < userData.Places_visited.length; i++) {
           if (
-            !countryArray.some(country => {
+            !newCountryArray.some(country => {
               return (
                 country.countryId === userData.Places_visited[i].countryId &&
                 country.tripTiming === 0
               );
             })
           ) {
-            countryArray.push({
+            newCountryArray.push({
               countryId: userData.Places_visited[i].countryId,
               country: userData.Places_visited[i].country,
               tripTiming: 0
@@ -95,14 +94,14 @@ const MapPage = ({
       if (userData != null && userData.Places_visiting.length !== 0) {
         for (let i = 0; i < userData.Places_visiting.length; i++) {
           if (
-            !countryArray.some(country => {
+            !newCountryArray.some(country => {
               return (
                 country.countryId === userData.Places_visiting[i].countryId &&
                 country.tripTiming === 1
               );
             })
           ) {
-            countryArray.push({
+            newCountryArray.push({
               countryId: userData.Places_visiting[i].countryId,
               country: userData.Places_visiting[i].country,
               tripTiming: 1
@@ -112,26 +111,25 @@ const MapPage = ({
       }
       if (userData != null && userData.Place_living !== null) {
         if (
-          !countryArray.some(country => {
+          !newCountryArray.some(country => {
             return (
               country.countryId === userData.Place_living.countryId &&
               country.tripTiming === 2
             );
           })
         ) {
-          countryArray.push({
+          newCountryArray.push({
             countryId: userData.Place_living.countryId,
             country: userData.Place_living.country,
             tripTiming: 2
           });
         }
       }
-      addCountry(countryArray);
+      addCountry(newCountryArray);
     }
-
     handleLoadedCountries(user);
     handleLoaded(true);
-  }, [user, clickedCountryArray]);
+  }, [user, countryArray]);
 
   function calculateTravelScore() {
     let newTravelScore = 0;
@@ -210,7 +208,7 @@ const MapPage = ({
         ) : (
           <CountryMap
             tripData={tripData}
-            clickedCountryArray={clickedCountryArray}
+            countryArray={countryArray}
             handleMapTypeChange={() => handleMapPageChange(1)}
             refetch={refetch}
             currentTiming={timing}

--- a/src/pages/Home/MapPage.js
+++ b/src/pages/Home/MapPage.js
@@ -22,6 +22,7 @@ const MapPage = ({
   const [travelScore, handleTravelScore] = useState(0);
   const [countryIdArray, handleCountryIdArray] = useState([]);
   const [travelScoreIndexArray, handleTravelScoreIndexArray] = useState([]);
+  const [timing, handleTimingChange] = useState(0);
   const [addMultiplePlaces] = useMutation(ADD_MULTIPLE_PLACES, {
     onCompleted() {
       localStorage.removeItem("clickedCityArray");
@@ -179,11 +180,24 @@ const MapPage = ({
     handleTravelScoreIndexArray(travelScoreIndexArray);
     handleCountryIdArray(countryIdArray);
     addMultiplePlaces({ variables: { clickedCityArray } });
-
   }
   if (!loaded) return <Loader />;
   return (
     <div className="map-container">
+      <div className="user-timing-control">
+        Enter the 
+        <select onChange={e => handleTimingChange(Number(e.target.value))}>
+          <option id="select-past" value={0}>
+            {mapPage ? "cities" : "countries"} you have visited
+          </option>
+          <option id="select-future" value={1}>
+            {mapPage ? "cities" : "countries"} you want to visit
+          </option>
+          <option id="select-live" value={2}>
+            {mapPage ? "city" : "country"} you live in
+          </option>
+        </select>
+      </div>
       <div className={mapPage ? "map city-map" : "map country-map"}>
         {mapPage ? (
           <CityMap
@@ -191,6 +205,7 @@ const MapPage = ({
             handleMapTypeChange={() => handleMapPageChange(0)}
             refetch={refetch}
             clickedCityArray={newClickedCityArray}
+            currentTiming={timing}
           />
         ) : (
           <CountryMap
@@ -198,6 +213,7 @@ const MapPage = ({
             clickedCountryArray={clickedCountryArray}
             handleMapTypeChange={() => handleMapPageChange(1)}
             refetch={refetch}
+            currentTiming={timing}
           />
         )}
       </div>

--- a/src/pages/Home/_MapPage.scss
+++ b/src/pages/Home/_MapPage.scss
@@ -16,9 +16,127 @@
   margin: 0 auto;
   .country-map {
     margin: 0px;
+    margin-top: 60px;
     height: calc(100% - 60px);
     position: relative;
     text-align: center;
+    .personal-map-share {
+      top: 0px;
+      color: #769f93;
+      background: $light-green;
+      box-shadow: 0 0 14px 2px rgba(197, 238, 143, 0.75);
+      svg {
+        margin-left: 6px;
+        fill: #769f93;
+      }
+      &:hover {
+        background: rgb(248, 248, 252);
+        color: #769f93;
+      }
+      @media screen and (max-width: 800px) {
+        left: calc(50% - 300px);
+      }
+      @media screen and (max-width: 700px) {
+        left: calc(50% - 210px);
+      }
+      @media screen and (max-width: 500px) {
+        left: calc(50% - 40px);
+      }
+    }
+    
+    .personal-map-save {
+      top: 44px;
+      color: rgb(248, 248, 252);
+      background: #73a7c3;
+      box-shadow: 0 0 14px 2px rgba(167, 225, 255, 0.75);
+      svg {
+        margin-left: 18px;
+        path {
+          fill: rgb(248, 248, 252);
+        }
+      }
+      &:hover {
+        background: rgb(248, 248, 252);
+        color: #73a7c3;
+    
+        svg path {
+          fill: #73a7c3;
+        }
+      }
+      @media screen and (max-width: 800px) {
+        left: calc(50% + 240px);
+      }
+      @media screen and (max-width: 700px) {
+        left: calc(50% + 160px);
+      }
+      @media screen and (max-width: 500px) {
+        left: calc(50% + 28px);
+      }
+    }
+    
+    .personal-map-share,
+    .personal-map-save {
+      position: absolute;
+      right: calc(50% - 600px);
+      display: flex;
+      align-items: center;
+      height: 40px;
+      font-size: 14px;
+      letter-spacing: 1.5px;
+      padding-left: 28px;
+      font-family: "Segoe UI", sans-serif;
+      border-radius: 24px;
+      border: 2px solid #fff;
+      width: 200px;
+      z-index: 1;
+      font-weight: 700;
+      cursor: pointer;
+      @media (max-width: "1250px") {
+        right: calc(50% - 440px);
+        width: 60px;
+        justify-content: center;
+        padding-left: 0px;
+        svg {
+          margin-left: 0;
+        }
+        span {
+          display: none;
+        }
+      }
+      @media screen and (max-width: 900px) {
+        right: calc(50% - 380px);
+      }
+      @media screen and (max-width: 800px) {
+        top: 16px;
+      }
+      @media screen and (max-width: 500px) {
+        top: 120px;
+      }
+      #myShareLink {
+        opacity: 0;
+        z-index: -100;
+        position: absolute;
+      }
+      svg {
+        width: 24px;
+        height: 24px;
+      }
+      @media screen and (max-width: 1250px) {
+        // right: calc(50% - 440px);
+      }
+    }
+    
+    .personal-map-save-noclick {
+      cursor: not-allowed;
+      opacity: 0.5;
+      &:hover {
+        color: rgb(248, 248, 252);
+        background: #73a7c3;
+        svg path {
+          fill: rgb(248, 248, 252);
+        }
+      }
+    }
     .rsm-svg {
       width: calc(100% - 0px);
       height: calc(100% - 100px);

--- a/src/pages/Home/subcomponents/CityMap.js
+++ b/src/pages/Home/subcomponents/CityMap.js
@@ -44,7 +44,6 @@ function CityMap(props) {
   const [activeTimings, handleActiveTimings] = useState([1, 1, 1]);
   const [loading, handleLoaded] = useState(true);
   const [cityTooltip, handleCityTooltip] = useState(null);
-  const [timingState, handleTimingState] = useState(0);
   const [suggestPopup, handleSuggestedPopup] = useState(false);
   const [suggestedCountryArray, handleSuggestedCountryArray] = useState([]);
   const [suggestedContinentArray, handleSuggestedContinentArray] = useState([]);
@@ -75,6 +74,11 @@ function CityMap(props) {
       window.removeEventListener("resize", resize);
     };
   }, []);
+
+  useEffect(() => {
+    handleSuggestedContinentArray([]);
+    handleSuggestedCountryArray([]);
+  }, [props.currentTiming])
 
   useEffect(() => {
     let oldActiveTimings = [...activeTimings];
@@ -579,7 +583,7 @@ function CityMap(props) {
     }
 
     if (
-      timingState === 2 &&
+      props.currentTiming === 2 &&
       (loadedClickedCityArray.some(city => city.tripTiming === 2) ||
         clickedCityArray.some(city => city.tripTiming === 2))
     ) {
@@ -588,7 +592,7 @@ function CityMap(props) {
     }
     if (
       loadedClickedCityArray.some(
-        city => city.cityId === cityId && city.tripTiming === timingState
+        city => city.cityId === cityId && city.tripTiming === props.currentTiming
       )
     ) {
       return;
@@ -608,13 +612,13 @@ function CityMap(props) {
       cityId,
       city_latitude: event.result.center[1],
       city_longitude: event.result.center[0],
-      tripTiming: timingState
+      tripTiming: props.currentTiming
     };
     handleMarkers(markers);
     if (
       !loadedClickedCityArray.some(
         city =>
-          city.cityId === newCityEntry.cityId && city.tripTiming === timingState
+          city.cityId === newCityEntry.cityId && city.tripTiming === props.currentTiming
       )
     ) {
       handleTripTimingCityHelper(newCityEntry);
@@ -665,7 +669,7 @@ function CityMap(props) {
   }
 
   function handleTripTimingCityHelper(city) {
-    if (timingState !== 1) {
+    if (props.currentTiming !== 1) {
       calculateNewTravelScore(city, "add");
     }
 
@@ -678,7 +682,7 @@ function CityMap(props) {
       cityId: city.cityId,
       city_latitude: city.city_latitude,
       city_longitude: city.city_longitude,
-      tripTiming: timingState
+      tripTiming: props.currentTiming
     });
     let pastCount = tripTimingCounts[0];
     let futureCount = tripTimingCounts[1];
@@ -687,7 +691,7 @@ function CityMap(props) {
     let newMarkerFutureDisplay = [...markerFutureDisplay];
     let newMarkerLiveDisplay = [...markerLiveDisplay];
     let color = "";
-    switch (timingState) {
+    switch (props.currentTiming) {
       case 0:
         pastCount++;
         tripTimingCounts[0] = pastCount;
@@ -814,12 +818,6 @@ function CityMap(props) {
     }
   }
 
-  function handleTimingChange(value) {
-    handleTimingState(Number(value));
-    handleSuggestedContinentArray([]);
-    handleSuggestedCountryArray([]);
-  }
-
   function _renderPopup() {
     return (
       cityTooltip && (
@@ -941,7 +939,7 @@ function CityMap(props) {
                   </span>
                 </div>
                 <div className="sc-controls" id="sc-controls-city-side-menu">
-                  {timingState !== 2 ? (
+                  {props.currentTiming !== 2 ? (
                     <span className="new-map-suggest" onClick={showSuggest}>
                       <span className="sc-control-label">Tap cities</span>
                       <span>
@@ -998,7 +996,7 @@ function CityMap(props) {
             <span>SHARE MY MAP</span>
             <ShareIcon />
           </div>
-          {timingState !== 2 ? (
+          {props.currentTiming !== 2 ? (
             <div
               className="sc-controls sc-controls-right"
               onClick={showSuggest}
@@ -1094,14 +1092,6 @@ function CityMap(props) {
         <span className="gs-title">{"GeorneyScore"}</span>
         <span className="gs-score">{Math.ceil(travelScore)}</span>
       </span>
-      <div className="user-timing-control">
-        Enter the
-        <select onChange={e => handleTimingChange(e.target.value)}>
-          <option value={0}>cities you have visited</option>
-          <option value={1}>cities you want to visit</option>
-          <option value={2}>city you live in</option>
-        </select>
-      </div>
       {suggestPopup ? (
         <div className="city-suggestions-prompt">
           <PopupPrompt
@@ -1114,7 +1104,7 @@ function CityMap(props) {
               handleContinents: handleContinents,
               handleCountries: handleCountries,
               handleClickedCity: handleTripTimingCityHelper,
-              timing: timingState
+              timing: props.currentTiming
             }}
           />
         </div>
@@ -1129,7 +1119,8 @@ CityMap.propTypes = {
   deleteCity: PropTypes.func,
   refetch: PropTypes.func,
   clickedCityArray: PropTypes.array,
-  initialTravelScore: PropTypes.number
+  initialTravelScore: PropTypes.number,
+  currentTiming: PropTypes.number
 };
 
 ClusterMarker.propTypes = {

--- a/src/pages/Home/subcomponents/CityMap.js
+++ b/src/pages/Home/subcomponents/CityMap.js
@@ -10,7 +10,8 @@ import { useMutation } from "@apollo/react-hooks";
 import {
   ADD_MULTIPLE_PLACES,
   NEW_GEORNEY_SCORE,
-  UPDATE_GEORNEY_SCORE
+  UPDATE_GEORNEY_SCORE,
+  GET_LOGGEDIN_USER_COUNTRIES
 } from "../../../GraphQL";
 
 import { TravelScoreCalculator } from "../../../TravelScore";
@@ -54,7 +55,15 @@ function CityMap(props) {
   const [newLiveCity, handleNewLiveCity] = useState();
   const [showSideMenu, handleSideMenu] = useState(false);
   const [addMultiplePlaces] = useMutation(ADD_MULTIPLE_PLACES, {
-    onCompleted() {}
+    refetchQueries: [
+      {
+        query: GET_LOGGEDIN_USER_COUNTRIES
+      }
+    ],
+    awaitRefetchQueries: true,
+    onCompleted() {
+      props.refetch();
+    }
   });
   const [updateGeorneyScore] = useMutation(UPDATE_GEORNEY_SCORE, {
     onCompleted() {

--- a/src/pages/Home/subcomponents/CountryMap.js
+++ b/src/pages/Home/subcomponents/CountryMap.js
@@ -10,6 +10,9 @@ import { useMutation } from "@apollo/react-hooks";
 import { ADD_MULTIPLE_PLACES } from "../../../GraphQL";
 
 import jsonData from "../../../world-topo-min.json";
+import ClickedCountryTiming from "../../../components/Prompts/ClickedCountry/ClickedCountryTiming";
+import PopupPrompt from "../../../components/Prompts/PopupPrompt";
+
 import MapSearch from "./MapSearch";
 import MapScorecard from "./MapScorecard";
 import MapInfoContainer from "./MapInfoContainer";
@@ -29,13 +32,17 @@ const CountryMap = props => {
     { name: "South America", coordinates: [-58.3816, -20.6037] },
     { name: "East Asia", coordinates: [121.4737, 31.2304] }
   ];
-  const [clickedCountryArray, handleClickedCountryArray] = useState([...props.countryArray]);
+  const [clickedCountry, handleNewCountry] = useState(0);
+  const [clickedCountryArray, handleClickedCountryArray] = useState([
+    ...props.countryArray
+  ]);
   const [clickedCityArray, handleClickedCityArray] = useState([]); // Named this way to re-use graphql mutation
   const [countryName, handleCountryName] = useState("country");
   const [capitalName, handleCapitalName] = useState("Capital");
   const [tripTimingCounts, handleTripTiming] = useState([0, 0, 0]);
   const [activeTimings, handleTimingCheckbox] = useState([1, 1, 1]);
   const [showSideMenu, handleSideMenu] = useState(false);
+  const [activePopup, showPopup] = useState(false);
   const [addMultiplePlaces] = useMutation(ADD_MULTIPLE_PLACES, {
     onCompleted() {
       props.refetch();
@@ -191,7 +198,9 @@ const CountryMap = props => {
   }
 
   function handleClickedCountry(geography) {
+    console.log(geography);
     countryInfo(geography);
+    handleNewCountry(geography);
     for (let i in clickedCountryArray) {
       if (
         clickedCountryArray[i].country === geography.properties.name &&
@@ -236,7 +245,20 @@ const CountryMap = props => {
         return;
       }
     }
-    console.log("country has already been saved");
+    console.log("already saved");
+    showPopup(true);
+  }
+
+  function checkForPreviousTrips(geography) {
+    console.log(geography);
+    let previousTrips = false;
+    console.log(clickedCountryArray);
+    for (let i in clickedCountryArray) {
+      if (clickedCountryArray[i].country === geography.properties.name) {
+        previousTrips = true;
+      }
+    }
+    return previousTrips;
   }
 
   function countryInfo(geography) {
@@ -439,20 +461,27 @@ const CountryMap = props => {
         />
         <MapInfoContainer countryName={countryName} capitalName={capitalName} />
       </div>
-      {/* {activePopup ? (
+      {activePopup ? (
         <PopupPrompt
           activePopup={activePopup}
           showPopup={showPopup}
-          component={ClickedCountryContainer}
+          component={ClickedCountryTiming}
           componentProps={{
             countryInfo: clickedCountry,
-            handleTripTiming: handleTripTimingHelper,
+            currentTiming:
+              props.currentTiming === 0
+                ? "past"
+                : props.currentTiming === 1
+                ? "future"
+                : "live",
+            // handleTripTiming: handleTripTimingHelper,
             previousTrips: checkForPreviousTrips(clickedCountry),
-            tripData: props.tripData,
+            showPopup: showPopup,
+            // tripData: props.tripData,
             refetch: props.refetch
           }}
         />
-      ) : null} */}
+      ) : null}
     </>
   );
 };

--- a/src/pages/Home/subcomponents/_CityMap.scss
+++ b/src/pages/Home/subcomponents/_CityMap.scss
@@ -437,7 +437,8 @@
     left: calc(50% - 60px);
   }
 }
-.city-map .georney-score,  #map-readonly .georney-score{
+.city-map .georney-score,
+#map-readonly .georney-score {
   position: absolute;
   bottom: 60px;
   left: calc(50% - 100px);
@@ -515,6 +516,7 @@
   font-family: "Segoe UI", sans-serif;
   font-size: 30px;
   color: rgb(248, 248, 252);
+  z-index: 5;
   @media screen and (max-width: 700px) {
     flex-direction: column;
     font-size: 24px;
@@ -522,13 +524,16 @@
   @media screen and (max-width: 500px) {
     left: calc(50% - 280px);
   }
+  select:active, select:hover {
+    outline: none
+  }
   select {
     background: none;
     border: none;
     font-family: "Segoe UI", sans-serif;
     font-size: 30px;
     color: rgb(248, 248, 252);
-    margin-left: 4px;
+    margin-left: 8px;
     border-bottom: 1px solid rgb(248, 248, 252);
     min-height: 32px;
     @media screen and (max-width: 700px) {
@@ -536,9 +541,23 @@
       font-size: 24px;
     }
     option {
-      background: #dee2e6;
-      color: rgb(74, 89, 90);
-      min-height: 32px;
+      min-height: 80px;
+      width: 400px;
+      &:hover {
+        background: none;
+      }
+    }
+    #select-past {
+      color: #cb7678;
+      background: #ecd7db;
+    }
+    #select-future {
+      color: #73a7c3;
+      background: #c2d7e5;
+    }
+    #select-live {
+      color: #96b1a8;
+      background: #d1dcdb;
     }
   }
 }
@@ -686,32 +705,32 @@
 }
 
 #new-country-scorecard {
-    .map-scorecard-container {
-      bottom: 60px;
-      left: 100px;
-      @media screen and (max-width: 1250px) {
-        display: none;
-      }
-      @media screen and (max-height: 500px) {
-        top: 180px;
-      }
+  .map-scorecard-container {
+    bottom: 60px;
+    left: 100px;
+    @media screen and (max-width: 1250px) {
+      display: none;
     }
-    .map-info-container {
-      bottom: 120px;
-      left: 100px;
-      @media (max-height: 900px) {
-        transform: translate(-40px, 140px);
-      }
+    @media screen and (max-height: 500px) {
+      top: 180px;
     }
   }
+  .map-info-container {
+    bottom: 120px;
+    left: 100px;
+    @media (max-height: 900px) {
+      transform: translate(-40px, 140px);
+    }
+  }
+}
 
-  .mapboxgl-ctrl-geocoder--icon-close {
-    margin-top: 4px;
-  }
+.mapboxgl-ctrl-geocoder--icon-close {
+  margin-top: 4px;
+}
 
-  .city-map-readonly {
-    .city-new-side-menu {
-      top: 0;
-      height: 100%;
-    }
+.city-map-readonly {
+  .city-new-side-menu {
+    top: 0;
+    height: 100%;
   }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Change Personal Country Map to have a timing dropdown like the Personal City Map. 

<!--- Describe your changes in detail -->
1) Add timing dropdown to the Personal Country Map
2) Allow for deletion of all cities of a particular timing when clicking on a country which is already filled in (If country has already been selected for a "past" visit and user is in the "past" timing, a popup will show up to allow them to delete all "past" cities for this country). Not the prettiest menu quite yet but I'm OK with making that a separate PR
3) Fixed error on switching a "live" city while on personal city map
4) Added ability to switch "live" country

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [    ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ X ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- Note: Also please make sure the console is empty at production and there are no eslint warnings -->

- [ ] The console is clean. No errors or linting warnings
