### PR TITLE
Fix for Issue with Lazy Import

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "graphql-tag": "^2.10.1",
     "history": "^4.10.1",
     "jwt-decode": "^2.2.0",
+    "lazy": "^1.0.11",
     "lodash": "^4.17.15",
     "lodash.flowright": "^3.5.0",
     "mapbox-gl": "^1.6.1",
@@ -74,6 +75,7 @@
     ]
   },
   "devDependencies": {
+    "acorn-dynamic-import": "^3.0.0",
     "babel-jest": "^24.8.0",
     "enzyme-to-json": "^3.4.4",
     "eslint": "^5.16.0",


### PR DESCRIPTION
Resolves an issue related to using `lazy` on newer versions of Node.

## Description

Adds _`lazy`_ to our project dependencies, as well as _`acorn-dynamic-import`_ to our dev dependencies to solve issues seen locally.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] The console is clean. No errors or linting warnings
