### PR TITLE
Allowing friend city map to be clicked on, leaderboard now can click …

### DIFF
--- a/src/pages/Home/FriendMapPage.js
+++ b/src/pages/Home/FriendMapPage.js
@@ -39,6 +39,7 @@ const FriendMapPage = ({ user }) => {
 
   function handleCities(cities) {
     handleClickedCityArray(cities);
+    handleFilteredCityArray(cities);
   }
 
   function handleFilteredCities(cities) {

--- a/src/pages/Home/subcomponents/BloggerFilterCard.js
+++ b/src/pages/Home/subcomponents/BloggerFilterCard.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-function BloggerFilterCard({ user, rank, handleClick, activeCard }) {
+function BloggerFilterCard({ user, handleClick, activeCard }) {
   function handleClickHelper(user) {
-    handleClick(user, rank);
+    handleClick(user);
   }
 
   return (
@@ -12,7 +12,6 @@ function BloggerFilterCard({ user, rank, handleClick, activeCard }) {
       className="user-trip-card leaderboard-card blogger-card"
       onClick={() => handleClickHelper(user)}
     >
-      {/* <span className="blogger-rank">{rank + 1}</span> */}
       <div className="utc-user-info-container">
         <span className="utc-username">{user.username}</span>
       </div>

--- a/src/pages/Home/subcomponents/BloggerLeaderboardPrompt.js
+++ b/src/pages/Home/subcomponents/BloggerLeaderboardPrompt.js
@@ -21,14 +21,15 @@ function BloggerLeaderboardPrompt({
     handleFilteredUsers(newFilteredUsers);
   }, [searchText]);
 
-  function handleClick(user, rank) {
+  function handleClick(user) {
     let state = true;
-    if (rank === activeBlogger) {
+    if (user.id === activeBlogger) {
       state = false;
-      rank = null;
+      handleActiveBlogger(null);
+    } else {
+      handleActiveBlogger(user.id);
     }
     sendUserClicked(user, state);
-    handleActiveBlogger(user.id);
   }
 
   return (

--- a/src/pages/Home/subcomponents/FriendCityMap.js
+++ b/src/pages/Home/subcomponents/FriendCityMap.js
@@ -7,9 +7,7 @@ import Cluster from "@urbica/react-map-gl-cluster";
 import Geocoder from "react-map-gl-geocoder";
 import MapScorecard from "./MapScorecard";
 import PopupPrompt from "../../../components/Prompts/PopupPrompt";
-import FilterCityMap from "../../../components/Prompts/FilterCityMap";
 import MapChangeIcon from "../../../icons/MapChangeIcon";
-import FilterIcon from "../../../icons/FilterIcon";
 import LeaderboardIcon from "../../../icons/LeaderboardIcon";
 import FriendClickedCityContainer from "../../../components/Prompts/FriendClickedCity/FriendClickedCityContainer";
 import FriendClickedCityBlank from "../../../components/Prompts/FriendClickedCity/FriendClickedCityBlank";
@@ -93,8 +91,6 @@ function FriendCityMap(props) {
     let newClusterParams = clusterParams;
     if (timingCountArray[0] > 0) {
       if (timingCountArray[0] > 2000) {
-        // newClusterParams.pastExtent = 512;
-        // newClusterParams.pastNodeSize = 32;
         newClusterParams.pastExtent = 1024;
         newClusterParams.pastNodeSize = 64;
       } else if (timingCountArray[0] > 1500) {


### PR DESCRIPTION
…and unclick people

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed bug where clicking on a city in the friends city map would lead to an error. It now brings up the correct popup. Also, fixed a bug where clicking on a leaderboard user would not toggle their cities in the filter. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!-- Note: Also please make sure the console is empty at production and there are no eslint warnings -->

- [ ] The console is clean. No errors or linting warnings
